### PR TITLE
fin fix drop down menu connects #18

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,6 @@
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .
+
+//= require jquery
+//= require bootstrap

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,9 @@
     <%= link_to "LENGA", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "What's LENGA?",  about_path  %></li>
-        <li><%= link_to "Help",   help_path %></li>
-        <li><%= link_to "Become a Tutor", become_a_tutor_path %></li>
+        <li><%= link_to t(:about),  about_path  %></li>
+        <li><%= link_to t(:help),   help_path %></li>
+        <li><%= link_to t(:become_a_tutor), become_a_tutor_path %></li>
         <li>
           <% if current_user %>
             <div class="dropdown">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,12 +9,17 @@
         <li>
           <% if current_user %>
             <div class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 <%= image_tag(current_user.image, class: "img-circular") %>
+              </a>
               <ul class="dropdown-menu" role="menu" aria-labelledby="menu1">
-                <li class="divider"><%= link_to "My Session", "#" %></li>
-                <li class="divider"><%= link_to "Language & Currency", "#" %></li>
-                <li class="divider"><%= link_to "Setting", "#" %></li>
-                <li class="divider"><%= link_to "Log Out", "#" %></li>
+                <li><%= link_to "My Session", "#" %></li>
+                <li class="divider"></li>
+                <li><%= link_to "Language & Currency", "#" %></li>
+                <li class="divider"></li>
+                <li><%= link_to "Setting", "#" %></li>
+                <li class="divider"></li>
+                <li><%= link_to "Log Out", "#" %></li>
               </ul>
             </div>
           <% else %>


### PR DESCRIPTION
・dropdown menuが表示されていなかった
　→application.jsの方で、jqueryとbootstrapを読み込む必要があった。
　→オープンするためのanchorタグを追加

・表示されてもなんか変
　→bootstrapの`li.divider`というクラスはテキストを持たず単体で使用されるものであった模様。ので、dividerだけをもつliとlinkをもつliに分解