### PR TITLE
fin modify redirect thing when not logged in connects #51

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,6 @@ module LengaApp
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.autoload_paths += %W(#{config.root}/lib)
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -262,10 +262,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = CustomAuthenticationFailure
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
@@ -280,6 +281,6 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
-config.omniauth :facebook, "195038621324840", "4e8e79aeb2f38976b8edf74733b4bcab", callback_url: "http://localhost:3000/users/auth/facebook/callback"
+  config.omniauth :facebook, "195038621324840", "4e8e79aeb2f38976b8edf74733b4bcab", callback_url: "http://localhost:3000/users/auth/facebook/callback"
 
 end

--- a/lib/custom_authentication_failure.rb
+++ b/lib/custom_authentication_failure.rb
@@ -1,0 +1,6 @@
+class CustomAuthenticationFailure < Devise::FailureApp
+  protected
+    def redirect_url
+      root_path + "users/auth/facebook"
+    end
+end


### PR DESCRIPTION
・deviseのデフォルトの挙動で、authenticate_user!のfilterでfailした時に、メールとパスワードのログイン画面に飛ぶようになっていたが、lengaではその認証を用意していなかったため、loginしてproceedしようとするとerrorしてしまっていた。
・redirect先をfacebook認証のactionとすることでsolve